### PR TITLE
商品詳細ページの表示、表示の条件分岐

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions   # ActiveHashを用いてのbelongs_toが設定できる
 
+  belongs_to :user
   belongs_to :category
   belongs_to :condition
   belongs_to :deli_fee

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,6 @@ class User < ApplicationRecord
     validates :first_kana, presence: true
   end
   validates :birthday, presence: true
+
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,56 +123,55 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', url:items_path, method: :post, class: "subtitle"  %>
+    <%= link_to '新規投稿商品', items_path, method: :post, class: "subtitle"  %>
     <ul class='item-lists' >
       <% @allitems.each do |i| %>
-      <li class='list'>    <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開 %>
-        <% unless @allitems.length == 0 %>
-          <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag  i.image, class: "item-img" %>
+        <li class='list'>    <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開 %>
+          <% unless @allitems.length == 0 %>
+            <%= link_to item_path(i.id), method: :get do %>
+              <div class='item-img-content'>
+                <%= image_tag  i.image, class: "item-img" %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
-          </div>
-
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= i.name %>
-            </h3>
-            <div class='item-price'>
-              <span><%= i.price %>円<br><%= i.deli_fee.name %></span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
               </div>
-            </div>
-          </div>
-          <% end %>
-        <% end %>
-      <% end %>  
-      </li>
 
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= i.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= i.price %>円<br><%= i.deli_fee.name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <% end %>  
+        </li>
+      <% end %>
 
       <% if @allitems.length == 0 %>  <%# @allitemsの中の要素数を数えている %>
         <li class='list'>
           <%= link_to '#' do %>
-          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              商品を出品してね！
-            </h3>
-            <div class='item-price'>
-              <span>99999999円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
               </div>
             </div>
-          </div>
           <% end %>
         </li>
       <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url:items_path, method: :post, local: true do |f| %>
+    <%= form_with model: @item, url:items_path(@item), method: :post, local: true do |f| %>
 
       
       <%= render 'shared/error_messages', model: f.object %> <%# インスタンスを渡してエラー時にメッセージ表示 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,25 +16,21 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.deli_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif user_signed_in? %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +39,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.deli_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
#what
商品詳細表示機能の実装
#why
商品詳細ページを表示させるため

#ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
#画像が表示されており、画像がリンク切れなどになっていないこと
#商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/6a780ad33be13de09af3ec42d6e37b0b

#ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/f52916552713316cae166c9b02394adc

#ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
#ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/ca9d64e33a128b06dfc62d9c2466cdf8

#ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
#売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
　※これらは商品購入機能実装後に実装