### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_session, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :edit_access, only: [:edit]
   before_action :get_item, only: [:show, :edit, :update]
 
@@ -31,7 +31,6 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to item_path
     else
-      # @item = Item.find(params[:id])
       render :edit
     end
   end
@@ -43,10 +42,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :text, :category_id, :condition_id, :deli_fee_id, :area_id, :day_id, :price, :image).merge(user_id: current_user.id)
-  end
-
-  def move_to_session
-    redirect_to new_user_session_path unless user_signed_in?
   end
 
   def edit_access

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_session, only: [:new, :create, :edit, :update]
+  before_action :edit_access, only: [:edit]
 
   def index
     @allitems = Item.all.order('created_at DESC')
@@ -50,7 +51,11 @@ class ItemsController < ApplicationController
   def move_to_session
     redirect_to new_user_session_path unless user_signed_in?
   end
-  # def move_to_root
-  #   redirect_to root_path  商品購入機能実装後に実装 売却済み商品のURL入れるとログイン中のユーザー誰でもトップへ
-  # end
+
+  def edit_access
+    @item = Item.find(params[:id])
+    unless  current_user.id == @item.user_id
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :get_item, only: [:show, :edit, :update]
   before_action :edit_access, only: [:edit]
   

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :edit_access, only: [:edit]
   before_action :get_item, only: [:show, :edit, :update]
+  before_action :edit_access, only: [:edit]
+  
 
   def index
     @allitems = Item.all.order('created_at DESC')
@@ -45,7 +46,6 @@ class ItemsController < ApplicationController
   end
 
   def edit_access
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user_id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,6 @@ class ItemsController < ApplicationController
     end
   end
 
-
-
   private
 
   def item_params
@@ -52,8 +50,6 @@ class ItemsController < ApplicationController
 
   def edit_access
     @item = Item.find(params[:id])
-    unless  current_user.id == @item.user_id
-      redirect_to root_path
-    end
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_session, only: [:new, :create, :edit, :update]
   before_action :edit_access, only: [:edit]
+  before_action :get_item, only: [:show, :edit, :update]
 
   def index
     @allitems = Item.all.order('created_at DESC')
@@ -21,15 +22,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -39,6 +37,9 @@ class ItemsController < ApplicationController
   end
 
   private
+  def get_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(:name, :text, :category_id, :condition_id, :deli_fee_id, :area_id, :day_id, :price, :image).merge(user_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,13 +29,11 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    item.update(item_params)
-    if item.valid?
-      item.save
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
       redirect_to item_path
     else
-      @item = Item.find(params[:id])
+      # @item = Item.find(params[:id])
       render :edit
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_session, only: [:new, :create]
+  before_action :move_to_session, only: [:new, :create, :edit, :update]
 
   def index
     @allitems = Item.all.order('created_at DESC')
@@ -23,6 +23,24 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    item.update(item_params)
+    if item.valid?
+      item.save
+      redirect_to item_path
+    else
+      @item = Item.find(params[:id])
+      render :edit
+    end
+  end
+
+
+
   private
 
   def item_params
@@ -32,4 +50,7 @@ class ItemsController < ApplicationController
   def move_to_session
     redirect_to new_user_session_path unless user_signed_in?
   end
+  # def move_to_root
+  #   redirect_to root_path  商品購入機能実装後に実装 売却済み商品のURL入れるとログイン中のユーザー誰でもトップへ
+  # end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,154 +7,153 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url:item_path, local: true do |f| %>
+    <%= form_with model: @item, url:item_path(@item), method: :put, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%= render 'shared/error_messages', model: f.object %>
 
-    <%# 出品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        出品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :image, id:"item-image" %>
-      </div>
-    </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <%# 出品画像 %>
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          出品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-      </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-      <div class="items-detail">
-        <div class="weight-bold-text">商品の詳細</div>
-        <div class="form">
-
-          <div class="weight-bold-text">
-            カテゴリー
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
-
-          <div class="weight-bold-text">
-            商品の状態
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
         </div>
       </div>
-      <%# /商品の詳細 %>
-
-      <%# 配送について %>
-      <div class="items-detail">
-        <div class="weight-bold-text question-text">
-          <span>配送について</span>
-          <a class="question" href="#">?</a>
+      <%# /出品画像 %>
+      <%# 商品名と商品説明 %>
+      <div class="new-items">
+        <div class="weight-bold-text">
+          商品名
+          <span class="indispensable">必須</span>
         </div>
-
-        <div class="form">
-
+        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
           <div class="weight-bold-text">
-            配送料の負担
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <%= f.collection_select(:deli_fee_id, DeliFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-
-          <div class="weight-bold-text">
-            発送元の地域
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
-
-          <div class="weight-bold-text">
-            発送までの日数
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-
+          <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
-
       </div>
-      <%# /配送について %>
+      <%# /商品名と商品説明 %>
 
-      <%# 販売価格 %>
-      <div class="sell-price">
-        <div class="weight-bold-text question-text">
-          <span>販売価格<br>(¥300〜9,999,999)</span>
-          <a class="question" href="#">?</a>
-        </div>
-        <div>
-          <div class="price-content">
-            <div class="price-text">
-              <span>価格</span>
+      <%# 商品の詳細 %>
+        <div class="items-detail">
+          <div class="weight-bold-text">商品の詳細</div>
+          <div class="form">
+
+            <div class="weight-bold-text">
+              カテゴリー
               <span class="indispensable">必須</span>
             </div>
-            <span class="sell-yen">¥</span>
-            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+            <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+
+            <div class="weight-bold-text">
+              商品の状態
+              <span class="indispensable">必須</span>
+            </div>
+            <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+          </div>
+        </div>
+        <%# /商品の詳細 %>
+
+        <%# 配送について %>
+        <div class="items-detail">
+          <div class="weight-bold-text question-text">
+            <span>配送について</span>
+            <a class="question" href="#">?</a>
           </div>
 
-          <div class="price-content">
-            <span>販売手数料 (10%)</span>
-            <span>
-              <span id='add-tax-price'></span>円
+          <div class="form">
+
+            <div class="weight-bold-text">
+              配送料の負担
+              <span class="indispensable">必須</span>
+            </div>
+            <%= f.collection_select(:deli_fee_id, DeliFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+
+            <div class="weight-bold-text">
+              発送元の地域
+              <span class="indispensable">必須</span>
+            </div>
+            <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+
+            <div class="weight-bold-text">
+              発送までの日数
+              <span class="indispensable">必須</span>
+            </div>
+            <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+
+          </div>
+
+        </div>
+        <%# /配送について %>
+
+        <%# 販売価格 %>
+        <div class="sell-price">
+          <div class="weight-bold-text question-text">
+            <span>販売価格<br>(¥300〜9,999,999)</span>
+            <a class="question" href="#">?</a>
+          </div>
+          <div>
+            <div class="price-content">
+              <div class="price-text">
+                <span>価格</span>
+                <span class="indispensable">必須</span>
+              </div>
+              <span class="sell-yen">¥</span>
+              <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+            </div>
+
+            <div class="price-content">
+              <span>販売手数料 (10%)</span>
+              <span>
+                <span id='add-tax-price'></span>円
+              </span>
+            </div>
+
+            <div class="price-content">
+              <span>販売利益</span>
+              <span>
+                <span id='profit'></span>円
+            </div>
             </span>
           </div>
-
-          <div class="price-content">
-            <span>販売利益</span>
-            <span>
-              <span id='profit'></span>円
-          </div>
-          </span>
         </div>
-      </div>
-      <%# /販売価格 %>
+        <%# /販売価格 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%=link_to 'もどる', "#", class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
-  </div>
   <% end %>
 
   <footer class="items-sell-footer">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url:item_path, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,91 +33,101 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
 
     <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
-        <div class="weight-bold-text">
-          カテゴリー
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
 
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+          <div class="weight-bold-text">
+            カテゴリー
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
         </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
+      </div>
+      <%# /商品の詳細 %>
+
+      <%# 配送について %>
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
         </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
+
+        <div class="form">
+
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:deli_fee_id, DeliFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+
+        </div>
+
+      </div>
+      <%# /配送について %>
+
+      <%# 販売価格 %>
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          </div>
+
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+          </div>
           </span>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
+      <%# /販売価格 %>
 
     <%# 注意書き %>
     <div class="caution">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -150,7 +150,7 @@ app/assets/stylesheets/items/new.css %>
       <%# 下部ボタン %>
       <div class="sell-btn-contents">
         <%= f.submit "変更する" ,class:"sell-btn" %>
-        <%=link_to 'もどる', "#", class:"back-btn" %>
+        <%=link_to 'もどる', item_path(@item), method: :get, class:"back-btn" %>
       </div>
       <%# /下部ボタン %>
     </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,8 +6,7 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url:items_path(@item), method: :post, local: true do |f| %>
-
-      
+    
       <%= render 'shared/error_messages', model: f.object %> <%# インスタンスを渡してエラー時にメッセージ表示 %>
       
       <%# 出品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item) , method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% elsif user_signed_in? %>
@@ -33,7 +33,7 @@
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
#what
商品情報編集機能の実装

#why
商品情報の編集を行うため

#ログイン状態の出品者だけが商品情報編集ページに遷移できること
https://gyazo.com/942d69b5627260151600df4b8ace935e

#必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
https://gyazo.com/cc772cff33a1cec72aa5300831169732

#商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
#商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
#何も編集せずに更新をしても画像無しの商品にならないこと
https://gyazo.com/c675d2df1e65f5251787b3375974e90c

#ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
https://gyazo.com/1bf18d5835fa2d055dff698a336add7e

#ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
https://gyazo.com/5c4f6d615d9d1dc4d687bbb3f39acea2

#エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させること）
#エラーメッセージの出力は、商品情報編集ページにて行うこと
https://gyazo.com/b6521b159e2627443206a216fdf09087

#出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
#ログアウト状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
  ※これらは商品購入機能実装後に実装